### PR TITLE
Add special case for .tar.gz

### DIFF
--- a/app/models/file.rb
+++ b/app/models/file.rb
@@ -46,7 +46,7 @@ module File0
       data.size
     end
 
-    def self.create(file, filetype, key = nil, gallery = nil)
+    def self.create(orig_filename, file, filetype, key = nil, gallery = nil)
       redis = File0::App.file_redis
 
       # Early returns for bad shit
@@ -61,7 +61,13 @@ module File0
         image_data = strip(image_data)
       end
       # Store in redis as json {'type':'file/whatever', 'data':'base64'}
-      filename = SecureRandom.hex(6) + ::File.extname(file.path)
+      basename = SecureRandom.hex(6)
+      # Special case for .tar.gz
+      if ::File.basename(orig_filename) =~ /.*tar\.gz$/
+        filename = basename + '.tar.gz'
+      else
+      filename = basename + ::File.extname(file.path)
+      end
       payload = {
         filetype: filetype,
         data: Base64.encode64(image_data).delete("\n"),

--- a/app/routes/gets.rb
+++ b/app/routes/gets.rb
@@ -26,7 +26,7 @@ module File0
       end
 
       # File endpoints
-      get %r(\/([\w]{12}(?:|\.[\w]+))$), mustermann_opts: {
+      get %r(\/([\w]{12}(?:|[\.[\w]+]+))$), mustermann_opts: {
         check_anchors: false
       } do
         path = params['captures'].first

--- a/app/routes/posts.rb
+++ b/app/routes/posts.rb
@@ -23,6 +23,7 @@ module File0
         @file_urls = []
         files.each do |file|
           @file_urls.push File0::File.create(
+            file[:filename],
             file[:tempfile],
             file[:type],
             cookies[:key],


### PR DESCRIPTION
Not an ideal solution, but .tar.gz is really only the
double-extension filetype anyone ever uses.